### PR TITLE
Fix WebRTC call handling and ICE candidate race conditions

### DIFF
--- a/core/node.py
+++ b/core/node.py
@@ -444,9 +444,8 @@ class MeshNode:
         })
 
     def _on_call_accept(self, msg: Message):
-        peer = self.discovery.get_peer(msg.sender_id)
-        if peer:
-            self.media.start_call(peer.ip, peer.media_port)
+        # Do not start the UDP media engine here — browser calls use WebRTC/ICE
+        # and binding the UDP socket on the same port causes ICE candidate bind errors.
         self._emit("call_accepted", {"peer_id": msg.sender_id})
 
     def _on_call_reject(self, msg: Message):
@@ -944,7 +943,8 @@ class MeshNode:
         msg = Message(msg_type=MsgType.CALL_ACCEPT, sender_id=NODE_ID,
                       sender_name=NODE_NAME, payload={})
         self.msg_server.send_to_peer(peer.ip, peer.tcp_port, msg, peer_id)
-        self.media.start_call(peer.ip, peer.media_port)
+        # Do not start the UDP media engine here — browser calls use WebRTC/ICE
+        # and binding the UDP socket on the same port causes ICE candidate bind errors.
         self.current_call_peer = peer_id
         self._emit("call_accepted", {"peer_id": peer_id})
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -607,7 +607,7 @@ socket.on('call_incoming', d => {
     showRinging(d.peer_name, d.call_type, true);
 });
 socket.on('call_outgoing', d => { showRinging(d.peer_name, d.call_type, false); });
-socket.on('call_accepted', d => { if(S.callDir==='outgoing') startWebRTC(true); });
+socket.on('call_accepted', d => { if(d.peer_id === S.callPeer && S.callDir === 'outgoing') startWebRTC(true); });
 socket.on('call_rejected', () => { cleanupCall(); hideCall(); toast('Call declined'); });
 socket.on('call_ended', () => { cleanupCall(); hideCall(); toast('Call ended'); });
 
@@ -919,7 +919,7 @@ function completeXfer(d){
 //  WEBRTC CALLS WITH LIVE METRICS
 // ═══════════════════════════════════════════════
 function initiateCall(type){
-    if(!S.activePeer)return;
+    if(!S.activePeer || S.callPeer)return;
     S.callPeer=S.activePeer; S.callType=type; S.callDir='outgoing';
     socket.emit('start_call',{peer_id:S.activePeer,call_type:type});
 }
@@ -927,6 +927,8 @@ function initiateCall(type){
 function acceptIncoming(){
     if(!S.callPeer)return;
     socket.emit('accept_call',{peer_id:S.callPeer});
+    document.getElementById('call-status-ring').textContent = 'Connecting...';
+    document.getElementById('btn-accept').style.display = 'none';
 }
 
 async function startWebRTC(isCaller){
@@ -956,9 +958,6 @@ async function startWebRTC(isCaller){
     const runtimeCfg = S.rtcConfig || { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }], iceTransportPolicy: S.rtcPolicy || 'all' };
     pc = new RTCPeerConnection(runtimeCfg);
     localStream.getTracks().forEach(t => pc.addTrack(t, localStream));
-
-    // In case ICE candidates arrived before pc was created.
-    flushPendingIce();
 
     pc.ontrack = (e) => {
         // Safari/Firefox may not always populate e.streams.
@@ -994,9 +993,12 @@ async function startWebRTC(isCaller){
                 toast('Network degradation detected: switching ICE to relay and retrying call');
                 const peer = S.callPeer;
                 const ctype = S.callType || 'audio';
+                const dir = S.callDir;
                 cleanupCall(false);
-                if(peer){
+                if(peer && dir === 'outgoing'){
                     socket.emit('start_call',{peer_id:peer,call_type:ctype});
+                } else {
+                    hangUp();
                 }
                 return;
             }


### PR DESCRIPTION
## Summary
This PR fixes several issues with WebRTC call establishment and ICE candidate handling to prevent race conditions and improve call reliability, particularly when network degradation triggers fallback mechanisms.

## Key Changes

**Frontend (templates/index.html):**
- Added peer ID validation to `call_accepted` handler to ensure the acceptance is for the correct peer, preventing cross-peer call confusion
- Added guard clause in `initiateCall()` to prevent initiating multiple simultaneous calls
- Updated `acceptIncoming()` to immediately update UI (show "Connecting..." and hide accept button) when accepting a call
- Removed premature `flushPendingIce()` call that could cause ICE candidates to be processed before the RTCPeerConnection was fully initialized
- Enhanced network degradation handling to only retry outgoing calls and properly hang up incoming calls that fail

**Backend (core/node.py):**
- Removed UDP media engine initialization from `_on_call_accept()` handler to prevent port binding conflicts with WebRTC/ICE
- Removed UDP media engine initialization from `accept_call()` method for the same reason
- Added clarifying comments explaining that browser calls use WebRTC/ICE exclusively and UDP socket binding causes ICE candidate bind errors

## Notable Implementation Details
- The peer ID validation in the `call_accepted` handler prevents a scenario where multiple peers could trigger call acceptance simultaneously
- Removing the premature `flushPendingIce()` call ensures ICE candidates are only processed after the RTCPeerConnection is ready to receive them
- The backend changes reflect that modern browser-based calls no longer use the legacy UDP media engine, avoiding resource conflicts
- Network degradation retry logic now distinguishes between outgoing calls (which can be retried) and incoming calls (which should be terminated)

https://claude.ai/code/session_01JCoT5azcWRhtkswd1cJRq9